### PR TITLE
Add the workflow to open new issues.

### DIFF
--- a/.github/workflows/open-new-eat-report-issue.yml
+++ b/.github/workflows/open-new-eat-report-issue.yml
@@ -27,5 +27,8 @@ jobs:
             ref: #
           pinned: false
           close-previous: false
+          assignees: "mokocm"
+          project: 1  
+          column: "WIP"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/open-new-eat-report-issue.yml
+++ b/.github/workflows/open-new-eat-report-issue.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set date
         run: echo YYYYMMDD=`date +%Y/%m/%d` >> $GITHUB_ENV
       - name: Create new eat report issue
-        uses: imjohnbo/issue-bot@3daae12aa54d38685d7ff8459fc8a2aee8cea98b
+        uses: imjohnbo/issue-bot@v3
         with:
           labels: "Eat Report"
           title: "${{ env.YYYYMMDD }} 食事レポート"

--- a/.github/workflows/open-new-eat-report-issue.yml
+++ b/.github/workflows/open-new-eat-report-issue.yml
@@ -1,0 +1,31 @@
+name: Open daily eat report issue
+on:
+  schedule:
+    - cron: '0 23 * * *'
+
+jobs:
+  create_new_issue:
+    name: Open daily eat report issues.
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Set date
+        run: echo YYYYMMDD=`date +%Y/%m/%d` >> $GITHUB_ENV
+      - name: Create new eat report issue
+        uses: imjohnbo/issue-bot@3daae12aa54d38685d7ff8459fc8a2aee8cea98b
+        with:
+          labels: "Eat Report"
+          title: "${{ env.YYYYMMDD }} 食事レポート"
+          body: |
+            |name|kcal|
+            |-----|---|
+            |昼ご飯|kcal|
+            |夜ご飯|kcal|
+            |total|kcal|
+
+            ref: #
+          pinned: false
+          close-previous: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
毎朝8時にissueを立てるworkflowを追加しました。
GitHubActionsのスケジュールが保証するのは指定した時刻にキューイングするのみなので、遅延を考慮して毎朝8時にしておきました。